### PR TITLE
Release 2.3.3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,8 +31,8 @@ android {
         applicationId = "es.mundodolphins.app"
         minSdk = 26
         targetSdk = 36
-        versionCode = 16
-        versionName = "2.3.2"
+        versionCode = 17
+        versionName = "2.3.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Release 2.3.3

- add commit message to release PR (#328) (e76ba1f)
- configure JaCoCo and clean up CI logs (#327) (90c9bed)
- improve connection management  of audio service (#326) (ceca808)
- build(deps): bump actions/github-script from 6 to 9 (#322) (6df048e)
- build(deps): bump actions/setup-java from 4 to 5 (#325) (73f6cec)
- build(deps): bump gradle/actions from 4 to 6 (#323) (fc813cf)
- build(deps): bump actions/checkout from 4 to 6 (#321) (75a6127)
- build(deps): bump actions/upload-artifact from 4 to 7 (#324) (c980964)
- build(deps): bump gradle-wrapper from 9.4.1 to 9.5.0 (#320) (5094de5)
- build(deps): bump kotlin from 2.3.20 to 2.3.21 (#319) (51a0797)
- build(deps): bump androidx.navigation:navigation-compose (#317) (117da5f)
- build(deps): bump com.google.devtools.ksp from 2.3.6 to 2.3.7 (#318) (67ae9d1)
- build(deps): bump androidx.compose:compose-bom (#316) (777229d)
- build(deps): bump androidx.compose.runtime:runtime-livedata (#315) (f212c24)
- build(deps): bump com.android.application from 9.1.1 to 9.2.0 (#314) (0bc21a7)
- build(deps): bump com.android.application from 9.1.0 to 9.1.1 (#313) (7f24d13)
- build(deps): bump com.google.firebase:firebase-bom (#312) (6487b87)
- build(deps): bump com.google.firebase.crashlytics from 3.0.6 to 3.0.7 (#311) (d106ca3)
- build(deps): bump media3Exoplayer from 1.9.3 to 1.10.0 (#310) (ec4fa34)
- build(deps): bump androidx.compose.runtime:runtime-livedata (#308) (b053894)
- build(deps): bump androidx.browser:browser from 1.9.0 to 1.10.0 (#309) (b9613f5)
- build(deps): bump androidx.compose:compose-bom (#307) (50b0c8c)
- build(deps): bump gradle-wrapper from 9.4.0 to 9.4.1 (#306) (d9a1335)
- build(deps): bump com.google.firebase:firebase-bom (#305) (f8c0867)
- refactor: clean up code and remove unused classes and methods (#304) (693a1bf)
- feat(deep-links): enhance deep link handling for episodes with new URI patterns and logging (#303) (3ae00fb)
- build(deps): bump kotlin from 2.3.10 to 2.3.20 (#302) (52f6ae4)
- build(deps): bump media3Exoplayer from 1.9.2 to 1.9.3 (#301) (a7bad35)

