### PR TITLE
Add CODEOWNERS and Mergify configuration for auto-merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,13 @@
+# Mergify configuration - auto-merge for javiyt's PRs after CI passes
+pull_request_rules:
+  - name: Automatic merge for javiyt's PRs after CI passes
+    conditions:
+      - "author=javiyt"
+      - "status-success=*"
+      - "base=main"
+      - "-conflict"
+      - "-draft"
+    actions:
+      rebase: {}
+      merge:
+        method: squash

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# This file was automatically created by a script.
+* @javiyt


### PR DESCRIPTION
This PR adds:
- `CODEOWNERS` with `* @javiyt` (so every PR has javiyt as codeowner)
- `.mergify.yml` to automatically merge PRs opened by **javiyt** when all CI checks pass and there are no conflicts.

The Mergify rule will:
- Rebase the PR before merging (ensuring it's up‑to‑date)
- Merge using the `squash` strategy

**Important:** Mergify must be installed in this repository or organization for this to work. If not, please install it from [Mergify GitHub App](https://github.com/marketplace/mergify).

Automated change via a script.
